### PR TITLE
adds environment variable to replace the host part

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This project provides a simple REST API bridge between [Music Assistant](https:/
 - **Basic Auth**  
   Basic authentication when USERNAME and PASSWORD environment variables are provided. This can also be accomplished with a reverse proxy instead.
 
+- **Replace URL**  
+  The server receives the url from music assistant and forwards this url to alexa, as the public url where the stream is available to alexa may vastly differ to the url that you are accessing music assistant (and is configured in music assistant frontend) you can replace that with a custom public url via environment variables like this:
+
 ## Usage
 
 ### Running Locally
@@ -38,7 +41,13 @@ This project provides a simple REST API bridge between [Music Assistant](https:/
    By default, the server is available without authentication. As this is insecure because the api must be publicly available. You can add basic authentication with the `USERNAME` and `PASSWORD` environment variables:
 
    ```sh
-   USERNAME=admin PASSWORD=test npm start
+   USERNAME=admin PASSWORD=test PUBLIC_URL=https://yourStreamSubDomain.yourDomain npm start
+   ```
+
+   The server receives the url from music assistant and forwards this url to alexa, as the public url where the stream is available to alexa may fastly differ to the url that you are accessing music assistant (and is configured in music assistant frontend) you can replace that with a custom public url via environment variables like this:
+
+   ```sh
+   PUBLIC_URL=https://yourStreamSubDomain.yourDomain npm start
    ```
 
 ### Building and Running with Docker
@@ -58,7 +67,7 @@ This project provides a simple REST API bridge between [Music Assistant](https:/
    You can provide the environment variables like this:
 
    ```sh
-   docker run --rm -d -e PORT=8080 -e USERNAME=admin -e PASSWORD=test -p 8080:8080 music-assistant-alexa-api
+   docker run --rm -d -e PORT=8080 -e USERNAME=admin -e PASSWORD=test -e PUBLIC_URL=https://yourStreamSubDomain.yourDomain -p 8080:8080 music-assistant-alexa-api
    ```
 
 ### Using GitHub Container Registry (GHCR) and Docker Run
@@ -72,7 +81,7 @@ This project provides a simple REST API bridge between [Music Assistant](https:/
 2. **Run the container:**
 
     ```sh
-    docker run --rm -d -p 3000:3000 -e USERNAME=admin -e PASSWORD=test ghcr.io/alams154/music-assistant-alexa-api:latest
+    docker run --rm -d -p 3000:3000 -e USERNAME=admin -e PASSWORD=test -e PUBLIC_URL=https://yourStreamSubDomain.yourDomain ghcr.io/alams154/music-assistant-alexa-api:latest
     ```
 
 ### Using GitHub Container Registry (GHCR) and Docker Compose
@@ -86,6 +95,7 @@ services:
     environment:
       - USERNAME=admin
       - PASSWORD=test
+      - PUBLIC_URL=https://yourStreamSubDomain.yourDomain
 ```
 
 ## API

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const app = express();
 const PORT = process.env.PORT | 3000;
 const USERNAME = process.env.USERNAME;
 const PASSWORD = process.env.PASSWORD;
+const PUBLIC_URL = process.env.PUBLIC_URL;
 
 process.on('SIGINT', () => {
   console.log('Received SIGINT. Exiting...');
@@ -47,8 +48,14 @@ app.post('/ma/push-url', (req, res) => {
     return res.status(400).json({ error: 'Missing required fields' });
   }
 
-  obj = { streamUrl };
   console.log('Received URL:', streamUrl);
+  if (PUBLIC_URL !== undefined) {
+    const publicUrl = streamUrl.replace(/^[^:]+:\/\/[^/]+/, PUBLIC_URL);
+    console.log('Replaced with Public URL:', publicUrl);
+    obj = { publicUrl };
+  } else {
+    obj = { streamUrl };
+  }
   res.json({ status: 'ok' });
 });
 


### PR DESCRIPTION
As music assistant on my setup is only available in my private network, also the base_url of music assistant is configured to a private ip. Therefore the received will be a private one like so:

`Received URL: http://172.16.3.2:8097/flow/HZfU**7M/Echo Arbeitszimmer/***.flac`

Although I got a reverse proxy in place that redirects a public subdomain of mine to the stream url of music assistant. To solve that problem I added an environment variable called PUBLIC_URL which can be set to replace the host part of the received URL with the publicly available one like so:

`Replaced with Public URL: https://subdomain.domain/flow/H***sV7M/Echo Arbeitszimmer/*****1.flac`